### PR TITLE
Fix `dmg:GetInflictor` and `dmg:GetWeapon` on simple base sweps

### DIFF
--- a/lua/weapons/simple_base/sh_attack.lua
+++ b/lua/weapons/simple_base/sh_attack.lua
@@ -105,6 +105,7 @@ function SWEP:FireWeapon()
 	local damage = self:GetDamage()
 
 	local bullet = {
+		Attacker = ply,
 		Num = primary.Count,
 		Src = ply:GetShootPos(),
 		Dir = self:GetShootDir(),
@@ -120,7 +121,7 @@ function SWEP:FireWeapon()
 
 	self:ModifyBulletTable(bullet)
 
-	ply:FireBullets(bullet)
+	self:FireBullets(bullet)
 end
 
 function SWEP:ModifyBulletTable(bullet)


### PR DESCRIPTION
Moves FireBullets call to weapon so that GetInflictor and GetWeapon return the correct entity instead of the attacker