### PR TITLE
Set weapon for melee weapons

### DIFF
--- a/lua/weapons/simple_base_melee/sh_attack.lua
+++ b/lua/weapons/simple_base_melee/sh_attack.lua
@@ -184,6 +184,7 @@ function SWEP:GenericAttack(heavy)
 		dmg:SetDamage(damage)
 		dmg:SetDamageType(damageType)
 
+		dmg:SetWeapon(self)
 		dmg:SetInflictor(self)
 		dmg:SetAttacker(self:GetOwner())
 


### PR DESCRIPTION
Makes `dmg:GetWeapon` also return a valid entity when hit with a melee weapon